### PR TITLE
Old docker containers should be cleaned up

### DIFF
--- a/src/browser-time/browsertime.sh
+++ b/src/browser-time/browsertime.sh
@@ -4,7 +4,7 @@ echo "Saving reports into $REPORT_DIR/reports"
 
 echo "Getting data for: $1"
 
-docker run --shm-size=1g -v $REPORT_DIR/reports:/browsertime sitespeedio/browsertime $1
+docker run --rm --shm-size=1g -v $REPORT_DIR/reports:/browsertime sitespeedio/browsertime $1
 
 echo "Finished getting data for: $1"
 


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
To avoid cluttering the host system with an endless list of old browsertime docker containers, those should be cleaned up after they finish their job. Docker has builtin support for that, which can be enabled by adding `--rm` to the `run` command.
<!-- Why are these changes necessary? -->

**Why**:
To avoid cluttering the host system
<!-- How were these changes implemented? -->

**How**:
adding `--rm` to the `run` command
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A<!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
